### PR TITLE
[REFACTOR] #24 Refact ReservationCommandService

### DIFF
--- a/src/main/java/com/lamarfishing/core/log/statistic/domain/Statistic.java
+++ b/src/main/java/com/lamarfishing/core/log/statistic/domain/Statistic.java
@@ -84,8 +84,18 @@ public class Statistic {
         this.depositExpired++;
     }
 
+    public void addDepositExpired(Long count) {
+        this.depositExpired++;
+    }
+
     //입금마감 24시간전
     public void addDeposit24Hour() {
         this.deposit24Hour++;
     }
+
+    public void addDeposit24Hour(Long count){
+        this.deposit24Hour += count;
+    }
+
+
 }

--- a/src/main/java/com/lamarfishing/core/reservation/controller/ReservationController.java
+++ b/src/main/java/com/lamarfishing/core/reservation/controller/ReservationController.java
@@ -64,11 +64,9 @@ public class ReservationController {
      */
     @PatchMapping("/{reservationPublicId}/cancel-request")
     public ResponseEntity<ApiResponse<Void>> reservationCancelRequest(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-                                                                      @PathVariable("reservationPublicId") String publicId,
-                                                                      @RequestBody ReservationProcessUpdateRequest request) {
+                                                                      @PathVariable("reservationPublicId") String publicId) {
         User user = userService.findUser(authenticatedUser);
-        ReservationProcessUpdateCommand command = ReservationProcessUpdateCommand.from(request);
-        reservationCommandService.reservationCancelRequest(publicId, command);
+        reservationCommandService.reservationCancelRequest(publicId);
 
         return ResponseEntity.ok(ApiResponse.success("예약 취소에 성공하였습니다.", null));
     }

--- a/src/main/java/com/lamarfishing/core/reservation/controller/ReservationController.java
+++ b/src/main/java/com/lamarfishing/core/reservation/controller/ReservationController.java
@@ -62,27 +62,35 @@ public class ReservationController {
     /**
      * 예약자 취소 예약 신청
      */
-    @PatchMapping("/{reservationPublicId}/cancel-request")
-    public ResponseEntity<ApiResponse<Void>> reservationCancelRequest(@AuthenticationPrincipal AuthenticatedUser authenticatedUser,
-                                                                      @PathVariable("reservationPublicId") String publicId) {
-        User user = userService.findUser(authenticatedUser);
-        reservationCommandService.reservationCancelRequest(publicId);
+    @PostMapping("/{reservationPublicId}/cancel/request")
+    public ResponseEntity<ApiResponse<Void>> reservationRequestCancel(@PathVariable("reservationPublicId") String publicId) {
+        reservationCommandService.cancelRequest(publicId);
 
         return ResponseEntity.ok(ApiResponse.success("예약 취소에 성공하였습니다.", null));
     }
 
     /**
-     * 관리자 예약 상태 변경
+     * 관리자 - 예약자 입금 완료
      */
-    @PatchMapping("/{reservationPublicId}/process")
-    public ResponseEntity<ApiResponse<Void>> changeReservationProcess(@PathVariable("reservationPublicId") String publicId,
-                                                                      @RequestBody ReservationProcessUpdateRequest request) {
+    @PostMapping("/{reservationPublicId}/deposit/complete")
+    public ResponseEntity<ApiResponse<Void>> reservationCompleteDeposit(@PathVariable("reservationPublicId") String publicId) {
 
-        ReservationProcessUpdateCommand command = ReservationProcessUpdateCommand.from(request);
-        reservationCommandService.changeReservationProcess(publicId, command);
+        reservationCommandService.completeDeposit(publicId);
 
-        return ResponseEntity.ok(ApiResponse.success("예약 취소에 성공하였습니다."));
+        return ResponseEntity.ok(ApiResponse.success("입금 완료로 변경하였습니다.", null));
     }
+
+    /**
+     * 관리자 - 예약자 취소 완료
+     */
+    @PostMapping("/{reservationPublicId}/cancel/complete")
+    public ResponseEntity<ApiResponse<Void>> reservationCompleteCancel(@PathVariable("reservationPublicId") String publicId) {
+
+        reservationCommandService.completeCancel(publicId);
+
+        return ResponseEntity.ok(ApiResponse.success("예약 취소로 변경하였습니다.", null));
+    }
+
     /**
      * 예약 목록 조회
      */

--- a/src/main/java/com/lamarfishing/core/reservation/domain/Reservation.java
+++ b/src/main/java/com/lamarfishing/core/reservation/domain/Reservation.java
@@ -3,6 +3,7 @@ package com.lamarfishing.core.reservation.domain;
 import com.lamarfishing.core.common.domain.BaseTimeEntity;
 import com.lamarfishing.core.common.uuid.Uuid;
 import com.lamarfishing.core.coupon.domain.Coupon;
+import com.lamarfishing.core.reservation.exception.InvalidRequestContent;
 import com.lamarfishing.core.schedule.domain.Schedule;
 import com.lamarfishing.core.user.domain.User;
 import jakarta.persistence.*;
@@ -82,7 +83,15 @@ public class Reservation extends BaseTimeEntity {
                 .build();
     }
 
-    public void changeProcess(Process process) {
-        this.process = process;
+    public void requestCancel() {
+        if (!canRequestCancel()) {
+            throw new InvalidRequestContent();
+        }
+
+        this.process = Process.CANCEL_REQUESTED;
+    }
+
+    private boolean canRequestCancel() {
+        return this.process == Process.CANCEL_REQUESTED;
     }
 }

--- a/src/main/java/com/lamarfishing/core/reservation/domain/Reservation.java
+++ b/src/main/java/com/lamarfishing/core/reservation/domain/Reservation.java
@@ -83,7 +83,11 @@ public class Reservation extends BaseTimeEntity {
                 .build();
     }
 
+    // 상태 변경 메서드
     public void requestCancel() {
+        if (this.process == Process.CANCEL_REQUESTED) {
+            return;
+        }
         if (!canRequestCancel()) {
             throw new InvalidRequestContent();
         }
@@ -91,7 +95,39 @@ public class Reservation extends BaseTimeEntity {
         this.process = Process.CANCEL_REQUESTED;
     }
 
+    public void completeDeposit(){
+        if (this.process == Process.DEPOSIT_COMPLETED) {
+            return;
+        }
+
+        if (!canCompleteDeposit()) {
+            throw new InvalidRequestContent();
+        }
+        this.process = Process.DEPOSIT_COMPLETED;
+    }
+
+    public void completeCancel(){
+        if (this.process == Process.CANCEL_COMPLETED) {
+            return;
+        }
+
+        if (!canCompleteCancel()){
+            throw new InvalidRequestContent();
+        }
+        this.process = Process.CANCEL_COMPLETED;
+        this.schedule.decreaseCurrentHeadCount(this.headCount);
+    }
+
     private boolean canRequestCancel() {
+        return this.process == Process.RESERVE_COMPLETED;
+    }
+
+    private boolean canCompleteDeposit() {
+        return this.process == Process.RESERVE_COMPLETED;
+    }
+
+    private boolean canCompleteCancel() {
         return this.process == Process.CANCEL_REQUESTED;
     }
+
 }

--- a/src/main/java/com/lamarfishing/core/reservation/domain/Reservation.java
+++ b/src/main/java/com/lamarfishing/core/reservation/domain/Reservation.java
@@ -127,7 +127,7 @@ public class Reservation extends BaseTimeEntity {
     }
 
     private boolean canCompleteCancel() {
-        return this.process == Process.CANCEL_REQUESTED;
+        return this.process == Process.CANCEL_REQUESTED || this.process == Process.RESERVE_COMPLETED;
     }
 
 }

--- a/src/main/java/com/lamarfishing/core/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/lamarfishing/core/reservation/repository/ReservationRepository.java
@@ -19,4 +19,7 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long>,
     Optional<Long> findIdByPublicId(@Param("publicId") String publicId);
 
     Boolean existsByIdAndUserId(Long reservationId, Long userId);
+
+    @Query("select r from Reservation r join fetch r.schedule where r.publicId = :publicId")
+    Optional<Reservation> findByPublicIdWithSchedule(@Param("publicId") String publicId);
 }

--- a/src/main/java/com/lamarfishing/core/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/lamarfishing/core/reservation/repository/ReservationRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.lamarfishing.core.reservation.repository;
 
+import com.lamarfishing.core.reservation.domain.Reservation;
 import com.lamarfishing.core.reservation.dto.query.ReservationCommonDto;
 import com.lamarfishing.core.reservation.dto.common.ReservationSimpleDto;
 import com.lamarfishing.core.reservation.dto.query.ReservationDetailFlat;
@@ -9,9 +10,16 @@ import com.lamarfishing.core.reservation.domain.Reservation.Process;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ReservationRepositoryCustom {
     Page<ReservationSimpleDto> getReservations(Long userId, Process process, LocalDateTime from, LocalDateTime to, Long shipId, Pageable pageable);
     List<ReservationCommonDto> getReservations(Long id);
     ReservationDetailFlat getReservationDetail(Long reservationId);
+
+    List<Reservation> findReservationBetweenDeparture(LocalDateTime start, LocalDateTime end);
+    Long countReservationBetweenDeparture(LocalDateTime start, LocalDateTime end);
+
+    List<String> findPhonesByDeparture(LocalDateTime start, LocalDateTime end);
+    public Optional<LocalDateTime> findDeparture(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/lamarfishing/core/reservation/repository/ReservationRepositoryCustom.java
+++ b/src/main/java/com/lamarfishing/core/reservation/repository/ReservationRepositoryCustom.java
@@ -21,5 +21,6 @@ public interface ReservationRepositoryCustom {
     Long countReservationBetweenDeparture(LocalDateTime start, LocalDateTime end);
 
     List<String> findPhonesByDeparture(LocalDateTime start, LocalDateTime end);
-    public Optional<LocalDateTime> findDeparture(LocalDateTime start, LocalDateTime end);
+    Optional<LocalDateTime> findDeparture(LocalDateTime start, LocalDateTime end);
+    List<Reservation> findReservationByDeparture(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/com/lamarfishing/core/reservation/repository/ReservationRepositoryImpl.java
+++ b/src/main/java/com/lamarfishing/core/reservation/repository/ReservationRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.lamarfishing.core.reservation.repository;
 
+import com.lamarfishing.core.reservation.domain.Reservation;
 import com.lamarfishing.core.reservation.dto.query.ReservationCommonDto;
 import com.lamarfishing.core.reservation.dto.query.ReservationDetailFlat;
 import com.lamarfishing.core.ship.domain.QShip;
@@ -17,6 +18,7 @@ import com.lamarfishing.core.reservation.domain.Reservation.Process;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static com.lamarfishing.core.coupon.domain.QCoupon.coupon;
 import static com.lamarfishing.core.reservation.domain.QReservation.reservation;
@@ -101,6 +103,58 @@ public class ReservationRepositoryImpl implements ReservationRepositoryCustom {
                 .join(reservation.coupon, coupon)
                 .where(reservation.id.eq(reservationId))
                 .fetchOne();
+    }
+
+    @Override
+    public List<Reservation> findReservationBetweenDeparture(LocalDateTime start, LocalDateTime end){
+            return queryFactory.selectFrom(reservation)
+                    .join(reservation.schedule, schedule)
+                    .where(
+                            schedule.departure.goe(start),
+                            schedule.departure.lt(end),
+                            reservation.process.eq(Process.RESERVE_COMPLETED)
+                            )
+                    .fetch();
+    }
+
+    @Override
+    public Long countReservationBetweenDeparture(LocalDateTime start, LocalDateTime end){
+        return queryFactory.select(reservation.count())
+                .from(reservation)
+                .join(reservation.schedule, schedule)
+                .where(
+                        schedule.departure.goe(start),
+                        schedule.departure.lt(end),
+                        reservation.process.eq(Process.RESERVE_COMPLETED)
+                )
+                .fetchOne();
+    }
+
+    @Override
+    public List<String> findPhonesByDeparture(LocalDateTime start, LocalDateTime end) {
+        return queryFactory.select(user.phone)
+                .from(reservation)
+                .join(reservation.schedule, schedule)
+                .join(reservation.user, user)
+                .where(
+                        schedule.departure.goe(start),
+                        schedule.departure.lt(end),
+                        reservation.process.eq(Process.RESERVE_COMPLETED)
+                )
+                .fetch();
+    }
+
+    @Override
+    public Optional<LocalDateTime> findDeparture(LocalDateTime start, LocalDateTime end) {
+        return queryFactory.select(schedule.departure)
+                .from(reservation)
+                .join(reservation.schedule, schedule)
+                .where(
+                        schedule.departure.goe(start),
+                        schedule.departure.lt(end),
+                        reservation.process.eq(Process.RESERVE_COMPLETED)
+                )
+                .fetchFirst();
     }
 
     private BooleanExpression processEq(Process process) {

--- a/src/main/java/com/lamarfishing/core/reservation/service/command/ReservationCommandService.java
+++ b/src/main/java/com/lamarfishing/core/reservation/service/command/ReservationCommandService.java
@@ -31,30 +31,21 @@ import java.util.Locale;
 @Transactional
 public class ReservationCommandService {
 
-    private final UserRepository userRepository;
     private final ReservationRepository reservationRepository;
     private final ScheduleRepository scheduleRepository;
     private final MessageCommandService messageCommandService;
     private final StatisticRepository statisticRepository;
 
-
-
     /**
      * 일반 유저가 예약
      */
     // @PreAuthorize("hasAnyAuthority('GRADE_BASIC', 'GRADE_VIP')")
-    public void reservationCancelRequest(String publicId, ReservationProcessUpdateCommand command) {
+    public void reservationCancelRequest(String publicId) {
 
         ValidatePublicId.validateReservationPublicId(publicId);
 
         Reservation reservation = findReservation(publicId);
-        Process process = command.getProcess();
-
-        if (process != Reservation.Process.CANCEL_REQUESTED) {
-            throw new InvalidRequestContent();
-        }
-
-        reservation.changeProcess(process);
+        reservation.requestCancel();
     }
 
     /**

--- a/src/main/java/com/lamarfishing/core/reservation/service/command/ReservationCommandService.java
+++ b/src/main/java/com/lamarfishing/core/reservation/service/command/ReservationCommandService.java
@@ -25,6 +25,7 @@ import java.time.format.TextStyle;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -40,7 +41,7 @@ public class ReservationCommandService {
      * 일반 유저가 예약
      */
     // @PreAuthorize("hasAnyAuthority('GRADE_BASIC', 'GRADE_VIP')")
-    public void reservationCancelRequest(String publicId) {
+    public void cancelRequest(String publicId) {
 
         ValidatePublicId.validateReservationPublicId(publicId);
 
@@ -49,37 +50,32 @@ public class ReservationCommandService {
     }
 
     /**
-     * Admin이 예약 상태 변경
+     * 입금 완료
      */
-    // @PreAuthorize("hasAuthority('GRADE_ADMIN')")
-    public void changeReservationProcess(String publicId, ReservationProcessUpdateCommand command) {
+    public void completeDeposit(String publicId) {
 
         ValidatePublicId.validateReservationPublicId(publicId);
 
         Reservation reservation = findReservation(publicId);
-        Process process = command.getProcess();
-
-        if(process == Reservation.Process.CANCEL_REQUESTED) {
-            throw new InvalidRequestContent();
-        }
-
-        if (process == Reservation.Process.CANCEL_COMPLETED) {
-            reservation.changeProcess(process);
-
-            Schedule schedule = reservation.getSchedule();
-            schedule.decreaseCurrentHeadCount(reservation.getHeadCount());
-            sendReservationCanceledNotification(reservation);
-            return;
-        }
-
-        // 예약 완료
-        if(process == Process.RESERVE_COMPLETED) {
-            reservation.changeProcess(process);
-            return;
-        }
-        // 입금 완료
-        reservation.changeProcess(process);
+        reservation.completeDeposit();
     }
+
+    /**
+     * 예약 취소 완료
+     */
+    public void completeCancel(String publicId) {
+
+        ValidatePublicId.validateReservationPublicId(publicId);
+
+        Reservation reservation = reservationRepository.findByPublicIdWithSchedule(publicId)
+                .orElseThrow(ReservationNotFound::new);
+
+        reservation.completeCancel();
+
+//        메시지 전송 주석 처리
+//        sendReservationCanceledNotification(reservation);
+    }
+
     /**
      * private Method
      */
@@ -98,53 +94,31 @@ public class ReservationCommandService {
      * 입금 만료 마감 통계 분석
      */
 
-    @Transactional
     public void statisticPaymentDeadlineWarning(){
         LocalDate today = LocalDate.now();  //11월 22일
         LocalDate deadline = today.plusDays(4); //11월 26일
 
-        LocalDateTime scheduleStart = deadline.atStartOfDay();  //11월 26일 오전 0시
-        LocalDateTime scheduleEnd = deadline.atTime(23,59,59);  //11월 26일 23시 59분 59초
+        LocalDateTime start = deadline.atStartOfDay();
+        LocalDateTime end = deadline.plusDays(1).atStartOfDay();
 
-        Schedule schedule = scheduleRepository.findFirstByDepartureBetween(scheduleStart,scheduleEnd)
-                .orElse(null);
-
-        if (schedule == null) {
-            return;
-        }
-
-        List<Reservation> reservations = reservationRepository
-                .findByScheduleAndProcess(schedule, Reservation.Process.RESERVE_COMPLETED);
+        Long count = reservationRepository.countReservationBetweenDeparture(start, end);
 
         Statistic statistic = statisticRepository.findByDate(today);
-        for (Reservation reservation : reservations) {
-            statistic.addDeposit24Hour();
-        }
-
+        statistic.addDeposit24Hour(count);
     }
 
-    @Transactional
     public void statisticPaymentExpiredNotification(){
         LocalDate today = LocalDate.now();  //11월 22일
-        LocalDate deadline = today.plusDays(3); //11월 25일
+        LocalDate deadline = today.plusDays(4); //11월 26일
 
-        LocalDateTime scheduleStart = deadline.atStartOfDay();  //11월 25일 오전 0시
-        LocalDateTime scheduleEnd = deadline.atTime(23,59,59);
+        LocalDateTime start = deadline.atStartOfDay();
+        LocalDateTime end = deadline.plusDays(1).atStartOfDay();
 
-        Schedule schedule = scheduleRepository.findFirstByDepartureBetween(scheduleStart,scheduleEnd)
-                .orElse(null);
-
-        if (schedule == null) {
-            return;
-        }
-
-        List<Reservation> reservations = reservationRepository
-                .findByScheduleAndProcess(schedule, Reservation.Process.RESERVE_COMPLETED);
+        Long count = reservationRepository.countReservationBetweenDeparture(start, end);
 
         Statistic statistic = statisticRepository.findByDate(today);
-        for (Reservation reservation : reservations) {
-            statistic.addDepositExpired();
-        }
+        statistic.addDepositExpired(count);
+
     }
 
     /**
@@ -155,24 +129,16 @@ public class ReservationCommandService {
         LocalDate deadline = today.plusDays(4); //11월 26일
 
         LocalDateTime scheduleStart = deadline.atStartOfDay();  //11월 26일 오전 0시
-        LocalDateTime scheduleEnd = deadline.atTime(23,59,59);  //11월 26일 23시 59분 59초
+        LocalDateTime scheduleEnd = scheduleStart.plusDays(1);
 
-        Schedule schedule = scheduleRepository.findFirstByDepartureBetween(scheduleStart,scheduleEnd)
-                .orElse(null);
-
-        if (schedule == null) {
+        Optional<LocalDateTime> optionalScheduleDate = reservationRepository.findDeparture(scheduleStart, scheduleEnd);
+        if (optionalScheduleDate.isEmpty()) {
             return;
         }
 
-        List<Reservation> reservations = reservationRepository
-                .findByScheduleAndProcess(schedule, Reservation.Process.RESERVE_COMPLETED);
-
-        List<String> phones = new ArrayList<>();
-        for (Reservation reservation : reservations) {
-            phones.add(reservation.getUser().getPhone());
-        }
-
-        String msg = createPaymentWarningMessage(schedule);
+        List<String> phones = reservationRepository.findPhonesByDeparture(scheduleStart, scheduleEnd);
+        LocalDateTime scheduleDate = optionalScheduleDate.get();
+        String msg = createPaymentWarningMessage(scheduleDate);
 
         messageCommandService.sendMessage(phones,msg);
     }
@@ -180,7 +146,6 @@ public class ReservationCommandService {
     /**
      * 입금 만료
      */
-    @Transactional
     public void sendPaymentExpiredNotification(){
         LocalDate today = LocalDate.now();  //11월 22일
         LocalDate deadline = today.plusDays(3); //11월 25일
@@ -260,7 +225,7 @@ public class ReservationCommandService {
     }
 
     private void expireReservation(Reservation reservation) {
-        reservation.changeProcess(Reservation.Process.CANCEL_COMPLETED);
+//        reservation.changeProcess(Reservation.Process.CANCEL_COMPLETED);
 
         Schedule schedule = reservation.getSchedule();
         schedule.decreaseCurrentHeadCount(reservation.getHeadCount());
@@ -275,8 +240,8 @@ public class ReservationCommandService {
                 "쭈갑 예약 입금기한이 만료되어 예약이 자동 취소되었습니다.\n";
     }
 
-    private String createPaymentWarningMessage(Schedule schedule) {
-        LocalDate msgScheduleDate = schedule.getDeparture().toLocalDate();
+    private String createPaymentWarningMessage(LocalDateTime scheduleDate) {
+        LocalDate msgScheduleDate = scheduleDate.toLocalDate();
         String msgScheduleDay = getKoreanDay(msgScheduleDate);
 
         return "안녕하세요 쭈불 낚시입니다.\n" +

--- a/src/main/java/com/lamarfishing/core/schedule/repository/ScheduleRepositoryCustom.java
+++ b/src/main/java/com/lamarfishing/core/schedule/repository/ScheduleRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.lamarfishing.core.schedule.repository;
 
+import com.lamarfishing.core.schedule.domain.Schedule;
 import com.lamarfishing.core.schedule.dto.common.ScheduleMainDto;
 import com.lamarfishing.core.schedule.dto.common.TodayScheduleDto;
 import com.lamarfishing.core.schedule.dto.query.ReservationPopupFlatDto;


### PR DESCRIPTION
상태 값을 직접 전달하는 방식 제거하고 예약 도메인의 상태 전이를 명시적인 명령 API로 표현하였다.
이를 통해 API 의미 혼동 및 검증 로직 복잡도 감소 효과를 얻을 수 있다.

- cancelRequest
- completeDeposit
- completeCancel

그 외 변경사항으로는 자동 메시지 관련 메서드들을 join을 이용하여 간략화 시켰다.
- statisticPaymentDeadlineWarning
- statisticPaymentExpiredNotification
- sendPaymentDeadlineWarning
- sendPaymentExpiredNotification

